### PR TITLE
Updates documentation

### DIFF
--- a/doc/app/antsdr.rst
+++ b/doc/app/antsdr.rst
@@ -20,7 +20,7 @@ For this application note, the following hardware and software will be used:
 
         1. Dell XPS13 with Ubuntu 20.04.4
         2. USRP B200 mini
-        3. antsdr with custom SRS bitstream
+        3. AntSDR with custom SRS bitstream
         4. srsRAN
         5. SRS Zynq timestamping
         6. Analog Devices libiio and libad9361 software libraries
@@ -54,8 +54,26 @@ Building and configuring srsRAN
 .. code-block:: bash
 
     export BOARD_IP="192.168.1.10"
-    export FREQ_OFFSET="-4100"
-    export RX_GAIN=50
+    export FREQ_OFFSET="0"
+    export RX_GAIN="50"
+    export TIME_ADV_NSAMPLES="0"
+
+
+**NOTE (1):** we advise starting with *FREQ_OFFSET="0"* and *TIME_ADV_NSAMPLES="0"* and then manually
+adjusting them as required by the specific utilized hardware setup, in order to minimize the CFO and
+ensure a good time-alignment between eNB and UE.
+
+**NOTE (2):** the AntSDR bitsream has been built by default to implement an internal buffering stage in
+the timestamped DAC path supporting storage of up to 10x 8000 sample-packets coming from the CPU - that is,
+according to values set for the *CONFIG.PARAM_BUFFER_LENGTH* and *CONFIG.PARAM_MAX_DMA_PACKET_LENGTH*
+parameters of the
+`dac_fifo_timestamp_enabler <https://github.com/srsran/zynq_timestamping/tree/main/ip/ADI_timestamping/RTL_code/dac_fifo_timestamp_enabler.vhd>`_
+block the board's
+`system.tcl <https://github.com/srsran/zynq_timestamping/tree/main/projects/antsdr/src/bd/system.tcl#L340>`_
+script, which would theoretically enable storing 10 ms worth of signal up to 5 MHz BW (i.e., 7680 samples
+per subframe). Nevertheless, by default the
+`RF IIO driver <https://github.com/srsran/zynq_timestamping/tree/main/sw/lib/src/phy/rf/rf_iio_imp.c#L36>`_
+of 1920 samples - that is, 1 ms (one subframe) worth of signal for 1.4 MHz BW.
 
 2. Execute the initialization script. It will compile the srsRAN stack as well as the RF drivers
 utilized by the Zynq timestamping solution. Moreover, it will also modify the default srsenb and

--- a/doc/app/antsdr.rst
+++ b/doc/app/antsdr.rst
@@ -68,7 +68,7 @@ the timestamped DAC path supporting storage of up to 10x 8000 sample-packets com
 according to values set for the *CONFIG.PARAM_BUFFER_LENGTH* and *CONFIG.PARAM_MAX_DMA_PACKET_LENGTH*
 parameters of the
 `dac_fifo_timestamp_enabler <https://github.com/srsran/zynq_timestamping/tree/main/ip/ADI_timestamping/RTL_code/dac_fifo_timestamp_enabler.vhd>`_
-block the board's
+block in the board's
 `system.tcl <https://github.com/srsran/zynq_timestamping/tree/main/projects/antsdr/src/bd/system.tcl#L340>`_
 script, which would theoretically enable storing 10 ms worth of signal up to 5 MHz BW (i.e., 7680 samples
 per subframe). Nevertheless, by default the

--- a/doc/app/antsdr.rst
+++ b/doc/app/antsdr.rst
@@ -73,7 +73,7 @@ block the board's
 script, which would theoretically enable storing 10 ms worth of signal up to 5 MHz BW (i.e., 7680 samples
 per subframe). Nevertheless, by default the
 `RF IIO driver <https://github.com/srsran/zynq_timestamping/tree/main/sw/lib/src/phy/rf/rf_iio_imp.c#L36>`_
-of 1920 samples - that is, 1 ms (one subframe) worth of signal for 1.4 MHz BW.
+uses DMA packets of 1920 samples - that is, 1 ms (one subframe) worth of signal for 1.4 MHz BW.
 
 2. Execute the initialization script. It will compile the srsRAN stack as well as the RF drivers
 utilized by the Zynq timestamping solution. Moreover, it will also modify the default srsenb and

--- a/doc/app/plutosdr.rst
+++ b/doc/app/plutosdr.rst
@@ -74,7 +74,7 @@ the timestamped DAC path supporting storage of up to 4x 2000 sample-packets comi
 according to values set for the *CONFIG.PARAM_BUFFER_LENGTH* and *CONFIG.PARAM_MAX_DMA_PACKET_LENGTH*
 parameters of the
 `dac_fifo_timestamp_enabler <https://github.com/srsran/zynq_timestamping/tree/main/ip/ADI_timestamping/RTL_code/dac_fifo_timestamp_enabler.vhd>`_
-block the board's
+block in the board's
 `system.tcl <https://github.com/srsran/zynq_timestamping/tree/main/projects/pluto/src/bd/system.tcl#L345>`_
 script, which enables storing 4 ms worth of signal for 1.4 MHz BW (i.e., 1920 samples per subframe). This
 s aligned with the default

--- a/doc/app/plutosdr.rst
+++ b/doc/app/plutosdr.rst
@@ -20,7 +20,7 @@ For this application note, the following hardware and software will be used:
 
         1. Dell XPS13 with Ubuntu 20.04.4
         2. USRP B200 mini
-        3. PlutoSDR with custom SRS bitstream
+        3. ADALM-PLUTO SDR with custom SRS bitstream
         4. srsRAN
         5. SRS Zynq timestamping
         6. Analog Devices libiio and libad9361 software libraries
@@ -67,6 +67,19 @@ utilized by the Zynq timestamping solution.
     git clone https://github.com/srsran/zynq_timestamping.git --recursive
     cd app
     ./prepare.sh
+
+
+**NOTE:** the ADALM-PLUTO SDR bitsream has been built by default to implement an internal buffering stage in
+the timestamped DAC path supporting storage of up to 4x 2000 sample-packets coming from the CPU - that is,
+according to values set for the *CONFIG.PARAM_BUFFER_LENGTH* and *CONFIG.PARAM_MAX_DMA_PACKET_LENGTH*
+parameters of the
+`dac_fifo_timestamp_enabler <https://github.com/srsran/zynq_timestamping/tree/main/ip/ADI_timestamping/RTL_code/dac_fifo_timestamp_enabler.vhd>`_
+block the board's
+`system.tcl <https://github.com/srsran/zynq_timestamping/tree/main/projects/pluto/src/bd/system.tcl#L345>`_
+script, which enables storing 4 ms worth of signal for 1.4 MHz BW (i.e., 1920 samples per subframe). This
+s aligned with the default
+`RF IIO driver <https://github.com/srsran/zynq_timestamping/tree/main/sw/lib/src/phy/rf/rf_iio_imp.c#L36>`_
+implementation, which sets the actual DMA packet exchange to a fixed size of 1920 samples.
 
 Running
 *******

--- a/doc/app/zcu.rst
+++ b/doc/app/zcu.rst
@@ -472,7 +472,7 @@ parameters of the
 block, which would theoretically enable storing 8 ms worth of signal up to 10 MHz BW (i.e., 15360 samples
 per subframe). Nevertheless, by default the
 `RF IIO driver <https://github.com/srsran/zynq_timestamping/tree/main/sw/lib/src/phy/rf/rf_iio_imp.c#L36>`_
-of 1920 samples - that is, 1 ms (one subframe) worth of signal for 1.4 MHz BW.
+ouses DMA packets f 1920 samples - that is, 1 ms (one subframe) worth of signal for 1.4 MHz BW.
 
 Running
 *******

--- a/doc/app/zcu.rst
+++ b/doc/app/zcu.rst
@@ -472,7 +472,7 @@ parameters of the
 block, which would theoretically enable storing 8 ms worth of signal up to 10 MHz BW (i.e., 15360 samples
 per subframe). Nevertheless, by default the
 `RF IIO driver <https://github.com/srsran/zynq_timestamping/tree/main/sw/lib/src/phy/rf/rf_iio_imp.c#L36>`_
-ouses DMA packets f 1920 samples - that is, 1 ms (one subframe) worth of signal for 1.4 MHz BW.
+uses DMA packets of 1920 samples - that is, 1 ms (one subframe) worth of signal for 1.4 MHz BW.
 
 Running
 *******

--- a/doc/app/zcu.rst
+++ b/doc/app/zcu.rst
@@ -464,6 +464,16 @@ initialization script call as follows, so that it uses the Xilinx librfdc librar
 When the build finishes, you will find the application under the *bin_app/* subfolder. The
 binary needs then to be transferred to the board (e.g., in */home/srs/bin*).
 
+**NOTE:** both ZCU bitsreams have been built by default to implement an internal buffering stage in
+the timestamped DAC path supporting storage of up to 8x 16000 sample-packets coming from the CPU - that is,
+according to the default values for the *CONFIG.PARAM_BUFFER_LENGTH* and *CONFIG.PARAM_MAX_DMA_PACKET_LENGTH*
+parameters of the
+`dac_fifo_timestamp_enabler <https://github.com/srsran/zynq_timestamping/tree/main/ip/ADI_timestamping/RTL_code/dac_fifo_timestamp_enabler.vhd>`_
+block, which would theoretically enable storing 8 ms worth of signal up to 10 MHz BW (i.e., 15360 samples
+per subframe). Nevertheless, by default the
+`RF IIO driver <https://github.com/srsran/zynq_timestamping/tree/main/sw/lib/src/phy/rf/rf_iio_imp.c#L36>`_
+of 1920 samples - that is, 1 ms (one subframe) worth of signal for 1.4 MHz BW.
+
 Running
 *******
 


### PR DESCRIPTION
Clarifies use of parameters affecting the DMA packet size and its related RF IIO driver implementation.
Specifies use of RF frequency offset and time advance parameters in the end-to-end application note.